### PR TITLE
Set jvm file.encoding to UTF-8 for metadata-import

### DIFF
--- a/bin-src/dspaceBatch.sh
+++ b/bin-src/dspaceBatch.sh
@@ -144,6 +144,7 @@ then
 
 elif [ "$1" = "metadata-import" ]
 then
+  export JAVA_OPTS="-Dfile.encoding=UTF-8"
   ${DSROOT}/bin/dspace "$@" >> ${RUNNING} 2>&1 
 
   while [ $# -ge 1 ]


### PR DESCRIPTION
Override default (US-ASCII) with UTF-8